### PR TITLE
e z fix for crash on images without parameters

### DIFF
--- a/scripts/image_scorer.py
+++ b/scripts/image_scorer.py
@@ -240,10 +240,12 @@ def on_before_image_saved(params: ImageSaveParams):
         for label, value in applied["info"].items():
             parts.append(f"{label}: {value}")
         if len(parts) > 0:
-            if len(params.pnginfo["parameters"]) > 0:
-                params.pnginfo["parameters"] += ", "
-            params.pnginfo["parameters"] += f"{', '.join(parts)}\n"
-    
+            try:
+                if len(params.pnginfo["parameters"]) > 0:
+                    params.pnginfo["parameters"] += ", "
+                params.pnginfo["parameters"] += f"{', '.join(parts)}\n"
+            except:
+                params.pnginfo["parameters"] = f"{', '.join(parts)}\n"
     return params
         
 def on_image_saved(params: ImageSaveParams):


### PR DESCRIPTION
Scoring was crashing if ran on images without parameters, this catches the crash and assigns it the new parameters data.